### PR TITLE
fix: use pipx instead of pip3

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -45,7 +45,7 @@ Run small checks *before* you commit
 
 
 * **🏗️ Setting it up:**
-  1. `pip3 install pre-commit`
+  1. `pipx install pre-commit`
   2. `cd <your repo>`
   3. `touch .pre-commit-config.yaml`
   3. `pre-commit install`
@@ -167,7 +167,7 @@ layout: two-cols
 * **Trying it out**:
 
 ```bash
-pip3 install cookiecutter
+pipx install cookiecutter
 # alternative: cruft https://...
 cookiecutter https://github.com/scikit-hep/cookie/
 # e.g., select project type = setuptools
@@ -281,7 +281,7 @@ this-is-part-of-a-filename
 **Option 2:** Synchronize Jupyter notebooks (untracked) to python files (tracked)
 
 ```bash
-pip3 install jupytext
+pipx install jupytext
 echo "*.ipynb" >> ~/.gitignore  # <-- tell git to ignore noteboks
 jupytext --to py mynotebook.ipynb
 # Now you have mynotebook.py


### PR DESCRIPTION
This is nicer and builds on pipx mention before. We could also add a pipx slide similar to:

build: make SDists and wheels
twine: upload SDists and wheels
cibuildwheel: make redistributable wheels
nox/tox: Python task runners
jupylite: WebAssembly Python site builder
black: Python code formatter
pypi-command-line: query PyPI

uproot-browser: ROOT file browser (HEP)
tiptop: fancy top-style monitor
rich-cli: pretty print files
cookiecutter: template packages
clang-format: format C/C++/CUDA code
pre-commit: general CQA tool
cmake: build system generator
meson: another build system generator
ninja: build system

https://www.slideshare.net/HenrySchreiner/code-quality-rse-group-meeting
